### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/server/test_helpers.go
+++ b/server/test_helpers.go
@@ -32,7 +32,7 @@ func FreeTCPAddr() (addr, port string, err error) {
 	defer closer()
 
 	portI := l.Addr().(*net.TCPAddr).Port
-	port = fmt.Sprintf("%d", portI)
+	port = strconv.Itoa(portI)
 	addr = fmt.Sprintf("tcp://0.0.0.0:%s", port)
 	return
 }

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -19,7 +19,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) {
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(
 				types.EventTypeInactiveProposal,
-				sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposal.ProposalID)),
+				sdk.NewAttribute(types.AttributeKeyProposalID, strconv.Itoa(proposal.ProposalID)),
 				sdk.NewAttribute(types.AttributeKeyProposalResult, types.AttributeValueProposalDropped),
 			),
 		)
@@ -88,7 +88,7 @@ func EndBlocker(ctx sdk.Context, keeper Keeper) {
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(
 				types.EventTypeActiveProposal,
-				sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposal.ProposalID)),
+				sdk.NewAttribute(types.AttributeKeyProposalID, strconv.Itoa(proposal.ProposalID)),
 				sdk.NewAttribute(types.AttributeKeyProposalResult, tagValue),
 			),
 		)

--- a/x/gov/client/utils/query.go
+++ b/x/gov/client/utils/query.go
@@ -39,7 +39,7 @@ func (p Proposer) String() string {
 func QueryDepositsByTxQuery(cliCtx context.CLIContext, params types.QueryProposalParams) ([]byte, error) {
 	events := []string{
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, types.TypeMsgDeposit),
-		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
+		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, []byte(strconv.Itoa(params.ProposalID))),
 	}
 
 	// NOTE: SearchTxs is used to facilitate the txs query which does not currently
@@ -81,7 +81,7 @@ func QueryDepositsByTxQuery(cliCtx context.CLIContext, params types.QueryProposa
 func QueryVotesByTxQuery(cliCtx context.CLIContext, params types.QueryProposalParams) ([]byte, error) {
 	events := []string{
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, types.TypeMsgVote),
-		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalVote, types.AttributeKeyProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
+		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalVote, types.AttributeKeyProposalID, []byte(strconv.Itoa(params.ProposalID))),
 	}
 
 	// NOTE: SearchTxs is used to facilitate the txs query which does not currently
@@ -118,7 +118,7 @@ func QueryVotesByTxQuery(cliCtx context.CLIContext, params types.QueryProposalPa
 func QueryVoteByTxQuery(cliCtx context.CLIContext, params types.QueryVoteParams) ([]byte, error) {
 	events := []string{
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, types.TypeMsgVote),
-		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalVote, types.AttributeKeyProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
+		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalVote, types.AttributeKeyProposalID, []byte(strconv.Itoa(params.ProposalID))),
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, []byte(params.Voter.String())),
 	}
 
@@ -158,7 +158,7 @@ func QueryVoteByTxQuery(cliCtx context.CLIContext, params types.QueryVoteParams)
 func QueryDepositByTxQuery(cliCtx context.CLIContext, params types.QueryDepositParams) ([]byte, error) {
 	events := []string{
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, types.TypeMsgDeposit),
-		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, []byte(fmt.Sprintf("%d", params.ProposalID))),
+		fmt.Sprintf("%s.%s='%s'", types.EventTypeProposalDeposit, types.AttributeKeyProposalID, []byte(strconv.Itoa(params.ProposalID))),
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeySender, []byte(params.Depositor.String())),
 	}
 
@@ -198,7 +198,7 @@ func QueryDepositByTxQuery(cliCtx context.CLIContext, params types.QueryDepositP
 func QueryProposerByTxQuery(cliCtx context.CLIContext, proposalID uint64) (Proposer, error) {
 	events := []string{
 		fmt.Sprintf("%s.%s='%s'", sdk.EventTypeMessage, sdk.AttributeKeyAction, types.TypeMsgSubmitProposal),
-		fmt.Sprintf("%s.%s='%s'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, []byte(fmt.Sprintf("%d", proposalID))),
+		fmt.Sprintf("%s.%s='%s'", types.EventTypeSubmitProposal, types.AttributeKeyProposalID, []byte(strconv.Itoa(proposalID))),
 	}
 
 	// NOTE: SearchTxs is used to facilitate the txs query which does not currently

--- a/x/gov/handler.go
+++ b/x/gov/handler.go
@@ -51,7 +51,7 @@ func handleMsgSubmitProposal(ctx sdk.Context, keeper Keeper, msg MsgSubmitPropos
 	submitEvent := sdk.NewEvent(types.EventTypeSubmitProposal, sdk.NewAttribute(types.AttributeKeyProposalType, msg.Content.ProposalType()))
 	if votingStarted {
 		submitEvent = submitEvent.AppendAttributes(
-			sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, fmt.Sprintf("%d", proposal.ProposalID)),
+			sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, strconv.Itoa(proposal.ProposalID)),
 		)
 	}
 	ctx.EventManager().EmitEvent(submitEvent)
@@ -80,7 +80,7 @@ func handleMsgDeposit(ctx sdk.Context, keeper Keeper, msg MsgDeposit) sdk.Result
 		ctx.EventManager().EmitEvent(
 			sdk.NewEvent(
 				types.EventTypeProposalDeposit,
-				sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, fmt.Sprintf("%d", msg.ProposalID)),
+				sdk.NewAttribute(types.AttributeKeyVotingPeriodStart, strconv.Itoa(msg.ProposalID)),
 			),
 		)
 	}

--- a/x/gov/keeper/deposit.go
+++ b/x/gov/keeper/deposit.go
@@ -134,7 +134,7 @@ func (keeper Keeper) AddDeposit(ctx sdk.Context, proposalID uint64, depositorAdd
 		sdk.NewEvent(
 			types.EventTypeProposalDeposit,
 			sdk.NewAttribute(sdk.AttributeKeyAmount, depositAmount.String()),
-			sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposalID)),
+			sdk.NewAttribute(types.AttributeKeyProposalID, strconv.Itoa(proposalID)),
 		),
 	)
 

--- a/x/gov/keeper/proposal.go
+++ b/x/gov/keeper/proposal.go
@@ -40,7 +40,7 @@ func (keeper Keeper) SubmitProposal(ctx sdk.Context, content types.Content) (typ
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeSubmitProposal,
-			sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposalID)),
+			sdk.NewAttribute(types.AttributeKeyProposalID, strconv.Itoa(proposalID)),
 		),
 	)
 

--- a/x/gov/keeper/vote.go
+++ b/x/gov/keeper/vote.go
@@ -28,7 +28,7 @@ func (keeper Keeper) AddVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.A
 		sdk.NewEvent(
 			types.EventTypeProposalVote,
 			sdk.NewAttribute(types.AttributeKeyOption, option.String()),
-			sdk.NewAttribute(types.AttributeKeyProposalID, fmt.Sprintf("%d", proposalID)),
+			sdk.NewAttribute(types.AttributeKeyProposalID, strconv.Itoa(proposalID)),
 		),
 	)
 

--- a/x/slashing/internal/keeper/infractions.go
+++ b/x/slashing/internal/keeper/infractions.go
@@ -83,7 +83,7 @@ func (k Keeper) HandleDoubleSign(ctx sdk.Context, addr crypto.Address, infractio
 		sdk.NewEvent(
 			types.EventTypeSlash,
 			sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
-			sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+			sdk.NewAttribute(types.AttributeKeyPower, strconv.Itoa(power)),
 			sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueDoubleSign),
 		),
 	)
@@ -156,8 +156,8 @@ func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, p
 			sdk.NewEvent(
 				types.EventTypeLiveness,
 				sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
-				sdk.NewAttribute(types.AttributeKeyMissedBlocks, fmt.Sprintf("%d", signInfo.MissedBlocksCounter)),
-				sdk.NewAttribute(types.AttributeKeyHeight, fmt.Sprintf("%d", height)),
+				sdk.NewAttribute(types.AttributeKeyMissedBlocks, strconv.Itoa(signInfo.MissedBlocksCounter)),
+				sdk.NewAttribute(types.AttributeKeyHeight, strconv.Itoa(height)),
 			),
 		)
 
@@ -188,7 +188,7 @@ func (k Keeper) HandleValidatorSignature(ctx sdk.Context, addr crypto.Address, p
 				sdk.NewEvent(
 					types.EventTypeSlash,
 					sdk.NewAttribute(types.AttributeKeyAddress, consAddr.String()),
-					sdk.NewAttribute(types.AttributeKeyPower, fmt.Sprintf("%d", power)),
+					sdk.NewAttribute(types.AttributeKeyPower, strconv.Itoa(power)),
 					sdk.NewAttribute(types.AttributeKeyReason, types.AttributeValueMissingSignature),
 					sdk.NewAttribute(types.AttributeKeyJailed, consAddr.String()),
 				),

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -961,7 +961,7 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 
 	// initialize some validators into the state
 	for i, power := range powers {
-		moniker := fmt.Sprintf("%d", i)
+		moniker := strconv.Itoa(i)
 		valPubKey := PKs[i+1]
 		valAddr := sdk.ValAddress(valPubKey.Address().Bytes())
 

--- a/x/staking/simulation/params.go
+++ b/x/staking/simulation/params.go
@@ -21,7 +21,7 @@ func ParamChanges(r *rand.Rand) []simulation.ParamChange {
 	return []simulation.ParamChange{
 		simulation.NewSimParamChange(types.ModuleName, keyMaxValidators, "",
 			func(r *rand.Rand) string {
-				return fmt.Sprintf("%d", GenMaxValidators(r))
+				return strconv.Itoa(GenMaxValidators(r))
 			},
 		),
 		simulation.NewSimParamChange(types.ModuleName, keyUnbondingTime, "",


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```